### PR TITLE
Use JupyterLite for the JupyterLab and Notebook demos

### DIFF
--- a/try.html
+++ b/try.html
@@ -14,7 +14,7 @@ applications_copy: |
     Click the boxes below to learn how they work and to learn more.
     If you like one, you can find <a href="/install">installation instructions here</a>.
 
-    ⚠️Exprimental⚠️ several of the environments below use the
+    ⚠️Experimental⚠️ several of the environments below use the
     <a href="https://jupyterlite.readthedocs.io/en/latest/">JupyterLite project</a> to provide a self-contained
     Jupyter environment that runs on your computer. This is experimental technology and
     may have some bugs, so please be patient and report any unexpected behavior in

--- a/try.html
+++ b/try.html
@@ -16,7 +16,7 @@ applications_copy: |
 
     ⚠️Experimental⚠️ several of the environments below use the
     <a href="https://jupyterlite.readthedocs.io/en/latest/">JupyterLite project</a> to provide a self-contained
-    Jupyter environment that runs on your computer. This is experimental technology and
+    Jupyter environment that runs in your browser. This is experimental technology and
     may have some bugs, so please be patient and report any unexpected behavior in
     <a href="https://github.com/jupyterlite/jupyterlite/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc">the JupyterLite repository</a>.
 

--- a/try.html
+++ b/try.html
@@ -14,6 +14,12 @@ applications_copy: |
     Click the boxes below to learn how they work and to learn more.
     If you like one, you can find <a href="/install">installation instructions here</a>.
 
+    ⚠️Exprimental⚠️ several of the environments below use the
+    <a href="https://jupyterlite.readthedocs.io/en/latest/">JupyterLite project</a> to provide a self-contained
+    Jupyter environment that runs on your computer. This is experimental technology and
+    may have some bugs, so please be patient and report any unexpected behavior in
+    <a href="https://github.com/jupyterlite/jupyterlite/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc">the JupyterLite repository</a>.
+
 kernels_copy: |
     Jupyter kernels allow you to use Jupyter interfaces and tools with <b>any programming language</b>.
     Below are interactive demos for a few languages to help demonstrate. You can also find
@@ -21,7 +27,7 @@ kernels_copy: |
 
 application_boxes:
     - title: JupyterLab
-      description: The latest web-based interactive development environment. ⚠️experimental⚠️this uses the <a href="https://jupyterlite.readthedocs.io/en/latest/">JupyterLite</a> package, please report any unexpected behavior.
+      description: The latest web-based interactive development environment
       src: try/jupyter.png
       alt: Jupyter logo - Launch JupyterLab demo Binder
       url: https://jupyter.org/try-jupyter/lab?path=notebooks%2FIntro.ipynb


### PR DESCRIPTION
Moves the JupyterLite copy into the intro paragraph instead of in the card.